### PR TITLE
Backfill missing lab metadata (8 files)

### DIFF
--- a/Instructions/Labs/LAB[PL-7002]_M00L00_Validate_lab_environment.md
+++ b/Instructions/Labs/LAB[PL-7002]_M00L00_Validate_lab_environment.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Lab 0: Validate lab environment'
-    module: 'Module 0: Course Introduction'
+  title: 'Lab 0: Validate lab environment'
+  module: 'Module 0: Course Introduction'
+  description: If you are being provided with a tenant as a part of an instructor-led
+    training delivery, please note that the tenant is made available for the purpose
+    of supporting the hands-on labs in the instructor-led training.
+  duration: 72 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 0 - Validate lab environment

--- a/Instructions/Labs/LAB[PL-7002]_M01L01_Create_flows.md
+++ b/Instructions/Labs/LAB[PL-7002]_M01L01_Create_flows.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 1: Create cloud flows'
-    module: 'Module 1: Get started with Power Automate'
+  title: 'Lab 1: Create cloud flows'
+  module: 'Module 1: Get started with Power Automate'
+  description: In this lab you will create cloud flows.
+  duration: 166 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 1 – Create cloud flows

--- a/Instructions/Labs/LAB[PL-7002]_M02L01_Data_model.md
+++ b/Instructions/Labs/LAB[PL-7002]_M02L01_Data_model.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 2: Data model'
-    module: 'Module 2: Get started with Microsoft Dataverse'
+  title: 'Lab 2: Data model'
+  module: 'Module 2: Get started with Microsoft Dataverse'
+  description: In this lab you will create Dataverse tables and columns.
+  duration: 156 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 2 – Data model

--- a/Instructions/Labs/LAB[PL-7002]_M03L01_SharePoint.md
+++ b/Instructions/Labs/LAB[PL-7002]_M03L01_SharePoint.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 3: SharePoint'
-    module: 'Module 3: Build approval flows with Power Automate'
+  title: 'Lab 3: SharePoint'
+  module: 'Module 3: Build approval flows with Power Automate'
+  description: In this lab you will create a SharePoint site and list.
+  duration: 140 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 3 – SharePoint

--- a/Instructions/Labs/LAB[PL-7002]_M03L02_Approval_flow.md
+++ b/Instructions/Labs/LAB[PL-7002]_M03L02_Approval_flow.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 4: Approval flow'
-    module: 'Module 3: Build approval flows with Power Automate'
+  title: 'Lab 4: Approval flow'
+  module: 'Module 3: Build approval flows with Power Automate'
+  description: In this lab you will create an approval flow.
+  duration: 156 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 4 – Approval flow

--- a/Instructions/Labs/LAB[PL-7002]_M04L01_Button_flow.md
+++ b/Instructions/Labs/LAB[PL-7002]_M04L01_Button_flow.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 5: Button flow'
-    module: 'Module 4: Build flows to manage user information'
+  title: 'Lab 5: Button flow'
+  module: 'Module 4: Build flows to manage user information'
+  description: In this lab you will create a button flow.
+  duration: 140 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 5 – Button flow

--- a/Instructions/Labs/LAB[PL-7002]_M05L01_Scheduled_flow.md
+++ b/Instructions/Labs/LAB[PL-7002]_M05L01_Scheduled_flow.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 6: Scheduled flow'
-    module: 'Module 5: Power Automate’s deep integration across multiple data sources'
+  title: 'Lab 6: Scheduled flow'
+  module: 'Module 5: Power Automate’s deep integration across multiple data sources'
+  description: In this lab you will create a scheduled flow.
+  duration: 148 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 6 – Scheduled flow

--- a/Instructions/Labs/LAB[PL-7002]_M05L02_Trigger_filters.md
+++ b/Instructions/Labs/LAB[PL-7002]_M05L02_Trigger_filters.md
@@ -1,7 +1,11 @@
 ---
 lab:
-    title: 'Lab 7: Trigger filters'
-    module: 'Module 5: Power Automate’s deep integration across multiple data sources'
+  title: 'Lab 7: Trigger filters'
+  module: 'Module 5: Power Automate’s deep integration across multiple data sources'
+  description: In this lab you will filter on an update trigger.
+  duration: 110 minutes
+  level: 100
+  islab: true
 ---
 
 # Practice Lab 7 – Trigger filters


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 8

- `Instructions/Labs/LAB[PL-7002]_M00L00_Validate_lab_environment.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7002]_M01L01_Create_flows.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7002]_M02L01_Data_model.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7002]_M03L01_SharePoint.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7002]_M03L02_Approval_flow.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7002]_M04L01_Button_flow.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7002]_M05L01_Scheduled_flow.md` (description,duration,level,islab)
- `Instructions/Labs/LAB[PL-7002]_M05L02_Trigger_filters.md` (description,duration,level,islab)
