### PR TITLE
Improve PL-7002 Lab 5 alignment with current Power Automate designer

### DIFF
--- a/Instructions/Labs/LAB[PL-7002]_M04L01_Button_flow.md
+++ b/Instructions/Labs/LAB[PL-7002]_M04L01_Button_flow.md
@@ -154,3 +154,5 @@ In this lab you will create a button flow.
 1. In the left navigation pane, select **Tables**.
 
 1. Select **Opportunity**.
+
+1. Verify that a **new opportunity record** was created.

--- a/Instructions/Labs/LAB[PL-7002]_M04L01_Button_flow.md
+++ b/Instructions/Labs/LAB[PL-7002]_M04L01_Button_flow.md
@@ -83,6 +83,8 @@ In this lab you will create a button flow.
 
 1. Select **Add a new row** under **Microsoft Dataverse**.
 
+1. Select **Change connection reference**.
+
 1. Enter `Dataverse` for **Connection name**.
 
 1. Select **Sign in**

--- a/Instructions/Labs/LAB[PL-7002]_M04L01_Button_flow.md
+++ b/Instructions/Labs/LAB[PL-7002]_M04L01_Button_flow.md
@@ -77,9 +77,9 @@ In this lab you will create a button flow.
 
 ### Task 1.3 - Add create opportunity action
 
-1. Select the **+** icon under the trigger step and select **Add an action**.
+1. Select the **+** icon under the trigger step to add an action.
 
-1. Enter `add row` in search.
+1. Enter `add row` in the search box.
 
 1. Select **Add a new row** under **Microsoft Dataverse**.
 

--- a/Instructions/Labs/LAB[PL-7002]_M04L01_Button_flow.md
+++ b/Instructions/Labs/LAB[PL-7002]_M04L01_Button_flow.md
@@ -51,8 +51,6 @@ In this lab you will create a button flow.
 
 1. Select the **Manually trigger a flow** step.
 
-1. Select the **Manually trigger a flow** step name and enter `Button triggered`
-
 1. Select **Add an input**.
 
 1. Select **Text**.


### PR DESCRIPTION
## Summary

This pull request updates **PL-7002 – Lab 5** to improve accuracy and alignment with the current Power Automate designer experience.

The changes remove unsupported trigger renaming instructions and clarify how to add actions and configure the Dataverse connection when creating the **Add a new row** action.

---

## Changes

- Removed the step instructing learners to rename the Manually trigger a flow trigger, as renaming is not supported for this trigger in the current designer.
- Updated Task 1.3 to clarify that learners should use the **+ (plus)** icon under the trigger to add an action.
- Refined search instructions to explicitly reference the **search box**.
- Added a step to select **Change connection reference** when configuring the **Add a new row** Dataverse action.
- Added a verification step to Task 2.2 to explicitly confirm that a new opportunity record was created after running the flow.
- Improved wording and sequencing to better reflect the current Power Automate UI.

---

## Files changed
 `Instructions/Labs/LAB[PL-7002]_M04L01_Button_flow.md`