### PR TITLE
Fix(pl-7002-lab1): improve instructions for Task 2.2 connection errors

### DIFF
--- a/Instructions/Labs/LAB[PL-7002]_M01L01_Create_flows.md
+++ b/Instructions/Labs/LAB[PL-7002]_M01L01_Create_flows.md
@@ -153,17 +153,28 @@ In this lab you will create cloud flows.
 
     ![Screenshot of flow step parameters.](../media/flow-step-parameters.png)
 
+1. Select the **Send an email** step.
+
+1. In the **Body** field, delete the existing content.
+
+1. Select the **dynamic value** icon or enter `/` to **Insert dynamic content**.
+
+1. In the search field, enter `daily summary`.
+
+1. Select **Day Summary**.
+
 1. Select **Save**.
 
-1. If an error is displayed for the *shared_msnweather* connection, select the icon in the bottom-right of the **Get forecast for today** action, select **Change connection reference**, select **Add new**, select **Create new**, and select **Save**.
+> [!NOTE]
+> If an error with status code **"Forbidden"** and details **"ConnectionAuthorizationFailed"** appears after saving, complete steps 10–13 to create new connections. If no error appears, skip to step 14.
 
-    ![Screenshot of Get forecast for today action.](../media/msn-connection.png)
+10. Select the **Get forecast for today** action, select **Change connection reference**, select **Add new**, and select **Create new**.
 
-1. If an error is displayed for the *shared_office365users* connection, select the icon in the bottom-right of the **Get my profile** action, select **Change connection reference**, select **Add new**, select **Sign in**, and select **Save**.
+1. Select the **Get my profile** action, select **Change connection reference**, select **Add new**, and select **Sign in**.
 
-1. If an error is displayed for the *shared_office365* connection, select the icon in the bottom-right of the **Send an email** action, select **Change connection reference**, select **Add new**, select **Sign in**, and select **Save**.
+1. Select the **Send an email** action, select **Change connection reference**, select **Add new**, and select **Sign in**.
 
-1. If still have errors with the connections, select the **<-** Back button from the top left of the command bar and restart this exercise.
+1. After creating the new connections for each action, select **Save**.
 
 1. To test the flow, select **Test**, select **Manually**, and then select **Test**.
 


### PR DESCRIPTION
## Summary

This pull request addresses issue #31, where learners encounter an error with status code **"Forbidden"** and details **"ConnectionAuthorizationFailed"** when attempting to save the flow in **Lab 1 - Exercise 2 - Task 2.2 (Configure flow step, Step 4)**. The original instructions did not provide clear guidance on how to resolve this connection authorization error, which occurs across multiple lab instances and tenants.

## Changes

* Replaced the previous vague single-step error handling instruction with a structured, step-by-step troubleshooting guide for connection errors.
* Added steps to configure the **Body** field of the **Send an email** action with dynamic content
* Added a **NOTE** block that clearly explains when the new steps (10–13) should be followed, specifically when the "Forbidden" / "ConnectionAuthorizationFailed" error appears after saving, and when they can be skipped.
* Provided explicit instructions for recreating each connection reference individually:
*   Step 10: **Get forecast for today** action → Change connection reference → Add new → Create new.
*   Step 11: **Get my profile** action → Change connection reference → Add new → Sign in.
*   Step 12: **Send an email** action → Change connection reference → Add new → Sign in.

* Added Step 14 instructing users to select **Save** after creating the new connections.
## Files changed

* `Instructions/Labs/LAB[PL-7002]_M01L01_Create_flows.md`

## Fixes
Fixes #31

## Successful tests
<img width="2991" height="1535" alt="image" src="https://github.com/user-attachments/assets/fc262d8a-5ee2-47a0-b748-856525651a5a" />

<img width="2988" height="1527" alt="image" src="https://github.com/user-attachments/assets/4ecd1043-c232-42c4-b897-48fa1bb6f90e" />

